### PR TITLE
feat: Update pricing details in the Pricing component and documentation

### DIFF
--- a/apps/landing/src/components/Pricing.astro
+++ b/apps/landing/src/components/Pricing.astro
@@ -68,14 +68,14 @@ import { Check, Plus } from "lucide-react";
           <CardDescription>For growing teams</CardDescription>
           <div class="mt-4">
             <div class="monthly-price">
-              <span class="text-4xl font-bold">$15</span>
+              <span class="text-4xl font-bold">$20</span>
               <span class="text-muted-foreground">/month</span>
             </div>
             <div class="annual-price hidden">
-              <span class="text-4xl font-bold">$12</span>
+              <span class="text-4xl font-bold">$16</span>
               <span class="text-muted-foreground">/month</span>
               <div class="text-sm text-muted-foreground mt-1">
-                <span class="line-through">$180</span> <span class="text-primary">$144/year</span>
+                <span class="line-through">$240</span> <span class="text-primary">$192/year</span>
               </div>
             </div>
           </div>
@@ -132,7 +132,7 @@ import { Check, Plus } from "lucide-react";
           <ul class="space-y-3">
             <li class="flex items-center">
               <Check className="w-5 h-5 text-primary mr-2 flex-shrink-0" />
-              <span>Unlimited PR reviews</span>
+              <span>Up to 2000 PR reviews per month</span>
             </li>
             <li class="flex items-center">
               <Check className="w-5 h-5 text-primary mr-2 flex-shrink-0" />
@@ -190,7 +190,7 @@ import { Check, Plus } from "lucide-react";
       
       <div class="text-center mt-4">
         <a href="#waitlist" class="inline-flex items-center text-primary hover:underline text-sm">
-          Contact us for custom volumes
+          Contact us for custom volumes or more than 2000 PR reviews
           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 ml-1" viewBox="0 0 20 20" fill="currentColor">
             <path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd" />
           </svg>

--- a/docs/proyect-context.md
+++ b/docs/proyect-context.md
@@ -120,7 +120,7 @@ The bot features an intuitive configuration system:
 - Community support
 - All core features included
 
-### Beard Master ($15/month or $144/year - 20% discount)
+### Beard Master ($20/month or $192/year - 20% discount)
 
 - For growing teams
 - Up to 500 PRs per month
@@ -132,7 +132,7 @@ The bot features an intuitive configuration system:
 ### Business ($49/month or $470/year - 20% discount)
 
 - For large organizations
-- Unlimited PRs
+- Up to 2000 PRs per month
 - Everything included in the Beard Master plan
 - Dedicated support
 - API integration (coming soon)
@@ -142,6 +142,7 @@ The bot features an intuitive configuration system:
 
 - Purchase extra PR batches
 - $5 for each additional 500 PRs
+- For more than 2000 PRs, please contact sales
 
 All plans include a 14-day free trial with no credit card required.
 


### PR DESCRIPTION
- Increased monthly price from $15 to $20 and annual price from $12 to $16 in the Pricing component.
- Updated the annual pricing display to reflect new total of $192/year.
- Changed PR review limit description from "Unlimited PR reviews" to "Up to 2000 PR reviews per month" in the Pricing component.
- Adjusted documentation to match updated pricing and features for the Beard Master and Business plans.